### PR TITLE
Add Render domain to allowed hosts

### DIFF
--- a/revisao_segura/settings.py
+++ b/revisao_segura/settings.py
@@ -18,7 +18,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # 🔹 Configuração do Django
 SECRET_KEY = config("DJANGO_SECRET_KEY", default="fallback_key_should_be_removed")
 DEBUG = False
-ALLOWED_HOSTS = ["www.verituscred.com.br", "verituscred.com.br", "127.0.0.1", "localhost"]
+ALLOWED_HOSTS = ["www.verituscred.com.br", "verituscred.com.br", "verituscred.onrender.com", "127.0.0.1", "localhost"]
 ROOT_URLCONF = "revisao_segura.urls"
 
 # 🔹 Configuração do Banco de Dados PostgreSQL


### PR DESCRIPTION
## Summary
- allow `verituscred.onrender.com` in `ALLOWED_HOSTS`

## Testing
- `DATABASE_URL=sqlite:///db.sqlite3 python manage.py test` *(fails: 'sslmode' is an invalid keyword argument for Connection())*

------
https://chatgpt.com/codex/tasks/task_e_68a514b19644832a9bdda6aa58b7aae6