### PR TITLE
Highlight Pix loan offering on main pages

### DIFF
--- a/templates/home.html
+++ b/templates/home.html
@@ -4,7 +4,10 @@
 
 {% block content %}
 <div class="container mt-5 text-center">
-    <h2 class="fw-bold"></h2>
-    <p class="lead"></p>
+    <h2 class="fw-bold">Empréstimos com liberação na hora</h2>
+    <p class="lead">Solicite seu crédito e receba via Pix imediatamente após aprovação.</p>
+    <a href="/simule/" class="btn-modern btn-lg fw-bold mt-3">
+        <i class="bi bi-cash-stack"></i> Simule agora
+    </a>
 </div>
 {% endblock %}

--- a/templates/servicos.html
+++ b/templates/servicos.html
@@ -33,9 +33,35 @@
         <p class="fs-5 fw-bold text-success">
             Nosso time acompanha você em todas as etapas para garantir a melhor escolha.
         </p>
+        <p class="fs-5">
+            Após a aprovação, o valor do empréstimo é transferido na hora via Pix para sua conta.
+        </p>
     </div>
     <div class="col-md-6">
         <img src="/static/images/emprestimo.jpg" class="img-fluid rounded shadow" alt="Opções de Empréstimo">
+    </div>
+</div>
+
+<!-- Destaques das Modalidades -->
+<div class="row mb-5">
+    <div class="col-md-6 mb-4">
+        <h4 class="fw-bold">Empréstimos</h4>
+        <p class="fs-5">
+            A forma ideal de realizar seus planos pessoais ou investir no seu negócio com praticidade.
+            Compare taxas, escolha o melhor prazo e contrate tudo online.
+        </p>
+        <p class="fs-5">
+            Após a aprovação, a liberação é imediata e o valor cai na hora via Pix.
+        </p>
+    </div>
+    <div class="col-md-6 mb-4">
+        <h4 class="fw-bold">Empréstimo Consignado</h4>
+        <p class="fs-5">
+            Parcelas descontadas diretamente do salário ou benefício, com juros mais baixos e menos burocracia.
+        </p>
+        <p class="fs-5">
+            Indicado para aposentados, pensionistas e servidores que querem crédito seguro, com liberação na hora pelo Pix.
+        </p>
     </div>
 </div>
 
@@ -102,7 +128,7 @@
     </div>
     <div class="col-md-3 col-6 mb-4">
         <i class="bi bi-piggy-bank-fill text-success" style="font-size: 2.5rem;"></i>
-        <p><strong>4. Dinheiro na Conta</strong><br>Após aprovação, o valor é liberado rapidamente.</p>
+        <p><strong>4. Dinheiro na Conta</strong><br>Após aprovação, o valor é transferido na hora via Pix.</p>
     </div>
 </div>
 


### PR DESCRIPTION
## Summary
- remove unused loan templates
- add Pix loan info to home page
- mention Pix transfer in services page steps
- expand services page with loan and consignado details

## Testing
- `python manage.py test` *(fails: ValueError: No support for '')*


------
https://chatgpt.com/codex/tasks/task_e_68a5bacbc094832a841347231df01cd6